### PR TITLE
Add node version for staging

### DIFF
--- a/assets/package.json
+++ b/assets/package.json
@@ -17,5 +17,8 @@
     "node-sass": "^4.9.0",
     "sass-brunch": "^2.10.4",
     "uglify-js-brunch": "2.10.0"
+  },
+  "engines": {
+    "node": "8.9.4"
   }
 }


### PR DESCRIPTION
On Heroku.
 
Heroku was blocking deployment because it was running on v6.9.2.
 
We are now matching our dev environment(i.e. v8.9.4)