### PR TITLE
PR 24 review--add acceptance test & troubleshoot chromedriver fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+sudo: required
 language: elixir
 
 elixir:

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,5 +27,6 @@ before_script:
   - nohup chromedriver &
   - sleep 10
 script:
-  - mix credo
   - mix test
+  - mix credo
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,14 @@ before_install:
   # - "export DISPLAY=:99.0"
   # - "sh -e /etc/init.d/xvfb start"
   # - sleep 10
+before_script:
+  - export DISPLAY=:99.0
+  - sh -e /etc/init.d/xvfb start
+  - export CHROMEDRIVER_VERSION=`curl -s http://chromedriver.storage.googleapis.com/LATEST_RELEASE`
+  - curl -L -O "http://chromedriver.storage.googleapis.com/${CHROMEDRIVER_VERSION}/chromedriver_linux64.zip"
+  - unzip chromedriver_linux64.zip
+  - sudo chmod +x chromedriver
+  - sudo mv chromedriver /usr/local/bin
 script:
   - mix credo
   - mix test

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,7 @@ before_script:
   - unzip chromedriver_linux64.zip
   - sudo chmod +x chromedriver
   - sudo mv chromedriver /usr/local/bin
+  - chromedriver
 script:
   - mix credo
   - mix test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 sudo: required
-# dist: trusty
-os: osx
+dist: trusty
+# os: osx
 language: elixir
 otp_release:
   - 20.3
@@ -8,11 +8,10 @@ otp_release:
 elixir:
   - 1.6.4
 addons:
-  chrome: beta
+  chrome: stable
 before_install:
-  - "/Applications/Google\\ Chrome.app/Contents/MacOS/Google\\ Chrome --headless --disable-gpu --remote-debugging-port=9222 http://localhost &"
-
-  # - google-chrome-stable --headless --disable-gpu --remote-debugging-port=9222 http://localhost &
+  # - "/Applications/Google\\ Chrome.app/Contents/MacOS/Google\\ Chrome --headless --disable-gpu --remote-debugging-port=9222 http://localhost &"
+  - google-chrome-stable --headless --disable-gpu --remote-debugging-port=9222 http://localhost &
 # before_script:
   # - "export DISPLAY=:99.0"
   # - "sh -e /etc/init.d/xvfb start"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,33 +1,26 @@
-# sudo: required
-# dist: trusty
-# os: osx
+sudo: required
+dist: trusty
+os: osx
 language: elixir
-# otp_release:
-#   - 20.3
-
+otp_release:
+  - 20.3
 elixir:
   - 1.6.4
 addons:
   chrome: stable
-before_install:
-  # - "/Applications/Google\\ Chrome.app/Contents/MacOS/Google\\ Chrome --headless --disable-gpu --remote-debugging-port=9222 http://localhost &"
-  - google-chrome-stable --headless --disable-gpu --remote-debugging-port=9222 http://localhost &
-# before_script:
-  # - "export DISPLAY=:99.0"
-  # - "sh -e /etc/init.d/xvfb start"
-  # - sleep 10
 before_script:
   - export DISPLAY=:99.0
   - sh -e /etc/init.d/xvfb start
+  - sleep 3
   - export CHROMEDRIVER_VERSION=`curl -s http://chromedriver.storage.googleapis.com/LATEST_RELEASE`
   - curl -L -O "http://chromedriver.storage.googleapis.com/${CHROMEDRIVER_VERSION}/chromedriver_linux64.zip"
   - unzip chromedriver_linux64.zip
   - sudo chmod +x chromedriver
   - sudo mv chromedriver /usr/local/bin
   - nohup chromedriver &
-  # - google-chrome-stable --headless --disable-gpu --remote-debugging-port=9222 http://localhost &
-  # - sleep 10
+  - google-chrome-stable --headless --disable-gpu --remote-debugging-port=9222 http://localhost &
 script:
-  - mix credo
   - mix test
+  - mix credo
+
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ before_script:
   - sudo mv chromedriver /usr/local/bin
   - nohup chromedriver &
   - google-chrome-stable --headless --disable-gpu --remote-debugging-port=9222 http://localhost &
-  - sleep 10
+  # - sleep 10
 script:
   - mix credo
   - mix test

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,12 +19,12 @@ addons:
 before_script:
   # - export DISPLAY=:99.0
   # - sh -e /etc/init.d/xvfb start
-  # - export CHROMEDRIVER_VERSION=`curl -s http://chromedriver.storage.googleapis.com/LATEST_RELEASE`
-  # - curl -L -O "http://chromedriver.storage.googleapis.com/${CHROMEDRIVER_VERSION}/chromedriver_linux64.zip"
-  # - unzip chromedriver_linux64.zip
-  # - sudo chmod +x chromedriver
-  # - sudo mv chromedriver /usr/local/bin
-  # - nohup chromedriver &
+  - export CHROMEDRIVER_VERSION=`curl -s http://chromedriver.storage.googleapis.com/LATEST_RELEASE`
+  - curl -L -O "http://chromedriver.storage.googleapis.com/${CHROMEDRIVER_VERSION}/chromedriver_linux64.zip"
+  - unzip chromedriver_linux64.zip
+  - sudo chmod +x chromedriver
+  - sudo mv chromedriver /usr/local/bin
+  - nohup chromedriver &
   - google-chrome-stable --headless --disable-gpu --remote-debugging-port=9222 http://localhost &
   # - sleep 10
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,20 @@
-sudo: required
-dist: trusty
+# sudo: required
+# dist: trusty
+os: osx
 language: elixir
 
 elixir:
   - 1.6.4
 addons:
-  chrome: stable
+  chrome: beta
 before_install:
-  - google-chrome-stable --headless --disable-gpu --remote-debugging-port=9222 http://localhost &
-before_script:
-  - "export DISPLAY=:99.0"
-  - "sh -e /etc/init.d/xvfb start"
-  - sleep 10
+  - "/Applications/Google\\ Chrome.app/Contents/MacOS/Google\\ Chrome --headless --disable-gpu --remote-debugging-port=9222 http://localhost &"
+
+  # - google-chrome-stable --headless --disable-gpu --remote-debugging-port=9222 http://localhost &
+# before_script:
+  # - "export DISPLAY=:99.0"
+  # - "sh -e /etc/init.d/xvfb start"
+  # - sleep 10
 script:
   - mix credo
   - mix test

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,11 +19,11 @@ addons:
 before_script:
   - export DISPLAY=:99.0
   - sh -e /etc/init.d/xvfb start
-  # - export CHROMEDRIVER_VERSION=`curl -s http://chromedriver.storage.googleapis.com/LATEST_RELEASE`
-  # - curl -L -O "http://chromedriver.storage.googleapis.com/${CHROMEDRIVER_VERSION}/chromedriver_linux64.zip"
-  # - unzip chromedriver_linux64.zip
-  # - sudo chmod +x chromedriver
-  # - sudo mv chromedriver /usr/local/bin
+  - export CHROMEDRIVER_VERSION=`curl -s http://chromedriver.storage.googleapis.com/LATEST_RELEASE`
+  - curl -L -O "http://chromedriver.storage.googleapis.com/${CHROMEDRIVER_VERSION}/chromedriver_linux64.zip"
+  - unzip chromedriver_linux64.zip
+  - sudo chmod +x chromedriver
+  - sudo mv chromedriver /usr/local/bin
   # - nohup chromedriver &
   - google-chrome-stable --headless --disable-gpu --remote-debugging-port=9222 http://localhost &
   # - sleep 10

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ before_script:
   - unzip chromedriver_linux64.zip
   - sudo chmod +x chromedriver
   - sudo mv chromedriver /usr/local/bin
-  - chromedriver
+  - nohup chromedriver &
 script:
   - mix credo
   - mix test

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ elixir:
 addons:
   chrome: stable
 before_install:
-  google-chrome-stable --headless --disable-gpu --remote-debugging-port=9222 http://localhost &
+  - google-chrome-stable --headless --disable-gpu --remote-debugging-port=9222 http://localhost &
 script:
   - mix credo
   - mix test

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ addons:
 before_install:
   - google-chrome-stable --headless --disable-gpu --remote-debugging-port=9222 http://localhost &
 before_script:
-  ./chromedriver
+  - "export DISPLAY=:99.0"
 script:
   - mix credo
   - mix test

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,8 @@ otp_release:
 
 elixir:
   - 1.6.4
-# addons:
-#   chrome: stable
+addons:
+  chrome: stable
 # before_install:
   # - "/Applications/Google\\ Chrome.app/Contents/MacOS/Google\\ Chrome --headless --disable-gpu --remote-debugging-port=9222 http://localhost &"
   # - google-chrome-stable --headless --disable-gpu --remote-debugging-port=9222 http://localhost &
@@ -25,6 +25,7 @@ before_script:
   - sudo chmod +x chromedriver
   - sudo mv chromedriver /usr/local/bin
   - nohup chromedriver &
+  - google-chrome-stable --headless --disable-gpu --remote-debugging-port=9222 http://localhost &
   - sleep 10
 script:
   - mix test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 sudo: required
+dist: trusty
 language: elixir
 
 elixir:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ before_install:
 before_script:
   - "export DISPLAY=:99.0"
   - "sh -e /etc/init.d/xvfb start"
-  - sleep 3
+  - sleep 10
 script:
   - mix credo
   - mix test

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ before_install:
 before_script:
   - "export DISPLAY=:99.0"
   - "sh -e /etc/init.d/xvfb start"
+  - sleep 3
 script:
   - mix credo
   - mix test

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@
 # dist: trusty
 os: osx
 language: elixir
+otp_release:
+  - 20.3
 
 elixir:
   - 1.6.4

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ addons:
 before_install:
   - google-chrome-stable --headless --disable-gpu --remote-debugging-port=9222 http://localhost &
 before_script:
-  chromedriver
+  ./chromedriver
 script:
   - mix credo
   - mix test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-# sudo: required
+sudo: required
 # dist: trusty
 os: osx
 language: elixir

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 # sudo: required
-dist: trusty
+# dist: trusty
 # os: osx
 language: elixir
 # otp_release:

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,6 @@ before_script:
   - google-chrome-stable --headless --disable-gpu --remote-debugging-port=9222 http://localhost &
   - sleep 10
 script:
-  - mix test
   - mix credo
+  - mix test
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,7 @@ language: elixir
 
 elixir:
   - 1.6.4
-script: mix credo
+
+script:
+  - mix credo
+  - mix test

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,8 @@ addons:
   chrome: stable
 before_install:
   - google-chrome-stable --headless --disable-gpu --remote-debugging-port=9222 http://localhost &
+before_script:
+  chromedriver
 script:
   - mix credo
   - mix test

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,11 +7,11 @@ otp_release:
 
 elixir:
   - 1.6.4
-addons:
-  chrome: stable
-before_install:
+# addons:
+#   chrome: stable
+# before_install:
   # - "/Applications/Google\\ Chrome.app/Contents/MacOS/Google\\ Chrome --headless --disable-gpu --remote-debugging-port=9222 http://localhost &"
-  - google-chrome-stable --headless --disable-gpu --remote-debugging-port=9222 http://localhost &
+  # - google-chrome-stable --headless --disable-gpu --remote-debugging-port=9222 http://localhost &
 # before_script:
   # - "export DISPLAY=:99.0"
   # - "sh -e /etc/init.d/xvfb start"

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ before_install:
   - google-chrome-stable --headless --disable-gpu --remote-debugging-port=9222 http://localhost &
 before_script:
   - "export DISPLAY=:99.0"
+  - "sh -e /etc/init.d/xvfb start"
 script:
   - mix credo
   - mix test

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,7 @@ before_script:
   - sudo chmod +x chromedriver
   - sudo mv chromedriver /usr/local/bin
   - nohup chromedriver &
+  - sleep 10
 script:
   - mix credo
   - mix test

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,14 +17,14 @@ addons:
   # - "sh -e /etc/init.d/xvfb start"
   # - sleep 10
 before_script:
-  - export DISPLAY=:99.0
-  - sh -e /etc/init.d/xvfb start
-  - export CHROMEDRIVER_VERSION=`curl -s http://chromedriver.storage.googleapis.com/LATEST_RELEASE`
-  - curl -L -O "http://chromedriver.storage.googleapis.com/${CHROMEDRIVER_VERSION}/chromedriver_linux64.zip"
-  - unzip chromedriver_linux64.zip
-  - sudo chmod +x chromedriver
-  - sudo mv chromedriver /usr/local/bin
-  - nohup chromedriver &
+  # - export DISPLAY=:99.0
+  # - sh -e /etc/init.d/xvfb start
+  # - export CHROMEDRIVER_VERSION=`curl -s http://chromedriver.storage.googleapis.com/LATEST_RELEASE`
+  # - curl -L -O "http://chromedriver.storage.googleapis.com/${CHROMEDRIVER_VERSION}/chromedriver_linux64.zip"
+  # - unzip chromedriver_linux64.zip
+  # - sudo chmod +x chromedriver
+  # - sudo mv chromedriver /usr/local/bin
+  # - nohup chromedriver &
   - google-chrome-stable --headless --disable-gpu --remote-debugging-port=9222 http://localhost &
   # - sleep 10
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ before_script:
   - unzip chromedriver_linux64.zip
   - sudo chmod +x chromedriver
   - sudo mv chromedriver /usr/local/bin
-  # - nohup chromedriver &
+  - nohup chromedriver &
   - google-chrome-stable --headless --disable-gpu --remote-debugging-port=9222 http://localhost &
   # - sleep 10
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,14 +17,14 @@ addons:
   # - "sh -e /etc/init.d/xvfb start"
   # - sleep 10
 before_script:
-  # - export DISPLAY=:99.0
-  # - sh -e /etc/init.d/xvfb start
-  - export CHROMEDRIVER_VERSION=`curl -s http://chromedriver.storage.googleapis.com/LATEST_RELEASE`
-  - curl -L -O "http://chromedriver.storage.googleapis.com/${CHROMEDRIVER_VERSION}/chromedriver_linux64.zip"
-  - unzip chromedriver_linux64.zip
-  - sudo chmod +x chromedriver
-  - sudo mv chromedriver /usr/local/bin
-  - nohup chromedriver &
+  - export DISPLAY=:99.0
+  - sh -e /etc/init.d/xvfb start
+  # - export CHROMEDRIVER_VERSION=`curl -s http://chromedriver.storage.googleapis.com/LATEST_RELEASE`
+  # - curl -L -O "http://chromedriver.storage.googleapis.com/${CHROMEDRIVER_VERSION}/chromedriver_linux64.zip"
+  # - unzip chromedriver_linux64.zip
+  # - sudo chmod +x chromedriver
+  # - sudo mv chromedriver /usr/local/bin
+  # - nohup chromedriver &
   - google-chrome-stable --headless --disable-gpu --remote-debugging-port=9222 http://localhost &
   # - sleep 10
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 sudo: required
 dist: trusty
-os: osx
 language: elixir
 otp_release:
   - 20.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,8 @@
 dist: trusty
 # os: osx
 language: elixir
-otp_release:
-  - 20.3
+# otp_release:
+#   - 20.3
 
 elixir:
   - 1.6.4

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,9 @@ elixir:
   - 1.6.4
 addons:
   chrome: stable
-# before_install:
+before_install:
   # - "/Applications/Google\\ Chrome.app/Contents/MacOS/Google\\ Chrome --headless --disable-gpu --remote-debugging-port=9222 http://localhost &"
-  # - google-chrome-stable --headless --disable-gpu --remote-debugging-port=9222 http://localhost &
+  - google-chrome-stable --headless --disable-gpu --remote-debugging-port=9222 http://localhost &
 # before_script:
   # - "export DISPLAY=:99.0"
   # - "sh -e /etc/init.d/xvfb start"
@@ -25,7 +25,7 @@ before_script:
   - sudo chmod +x chromedriver
   - sudo mv chromedriver /usr/local/bin
   - nohup chromedriver &
-  - google-chrome-stable --headless --disable-gpu --remote-debugging-port=9222 http://localhost &
+  # - google-chrome-stable --headless --disable-gpu --remote-debugging-port=9222 http://localhost &
   # - sleep 10
 script:
   - mix credo

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-sudo: required
+# sudo: required
 dist: trusty
 # os: osx
 language: elixir

--- a/config/test.exs
+++ b/config/test.exs
@@ -4,7 +4,7 @@ use Mix.Config
 # you can enable the server option below.
 config :championer_one, ChampionerOneWeb.Endpoint,
   http: [port: 4001],
-  server: false
+  server: true
 
 # Print only warnings and errors during test
 config :logger, level: :warn

--- a/test/championer_one_web/acceptance/page_index_test.exs
+++ b/test/championer_one_web/acceptance/page_index_test.exs
@@ -6,7 +6,7 @@ defmodule ChampionerOneWeb.PageIndexTest do
   hound_session()
 
   test "presence of welcome message", %{conn: conn} do
-    navigate_to "/" #page_path(conn, :index)
+    navigate_to page_path(conn, :index)
     assert page_source() =~ "Welcome to Championer"
 
   end

--- a/test/championer_one_web/acceptance/page_index_test.exs
+++ b/test/championer_one_web/acceptance/page_index_test.exs
@@ -1,0 +1,14 @@
+defmodule ChampionerOneWeb.PageIndexTest do
+  use ChampionerOneWeb.ConnCase
+  use ExUnit.Case
+  use Hound.Helpers
+  
+  hound_session()
+
+  test "presence of welcome message", %{conn: conn} do
+    navigate_to page_path(conn, :index)
+    assert page_source() =~ "Welcome to Championer"
+
+  end
+end
+

--- a/test/championer_one_web/acceptance/page_index_test.exs
+++ b/test/championer_one_web/acceptance/page_index_test.exs
@@ -6,7 +6,7 @@ defmodule ChampionerOneWeb.PageIndexTest do
   hound_session()
 
   test "presence of welcome message", %{conn: conn} do
-    navigate_to page_path(conn, :index)
+    navigate_to "/" #page_path(conn, :index)
     assert page_source() =~ "Welcome to Championer"
 
   end


### PR DESCRIPTION
PR 24 review--add acceptance test & troubleshoot chromedriver fail
 
Needed to write a simple acceptance test to verify that Hound was running properly.
 
It was not. *See trail of bit-by-bit commits I ran  and pushed to Travis, in order to isolate cause.*
 
...
 
The first fix was easy: `server: true` in `config/test.exs` to have the server run during tests.
 
More importantly, the `.travis.yml` configuration that  ended up being the solution was a combination of 3 things:
1. Start xvfb in order to imitate a graphical user interface display *(optionally, give it 3 seconds to start):*
```yml
before_script:
  - export DISPLAY=:99.0
  - sh -e /etc/init.d/xvfb start
  - sleep 3
```
2. Followed, in the before_script, by downloading chromedriver (in addition to google-chrome-stable):
```yml
  - export CHROMEDRIVER_VERSION=`curl -s http://chromedriver.storage.googleapis.com/LATEST_RELEASE`
  - curl -L -O "http://chromedriver.storage.googleapis.com/${CHROMEDRIVER_VERSION}/chromedriver_linux64.zip"
  - unzip chromedriver_linux64.zip
  - sudo chmod +x chromedriver
  - sudo mv chromedriver /usr/local/bin
```
(Lovingly borrowed from `github.com/keathley/wallaby`'s `.travis.yml` file
 
3. And finally, followed by actually starting chromedriver with a no hangup command and sending it to the background:
```yml
  - nohup chromedriver &
```
*REMEMBER:* In the before script, it is still needed to command google browser to run (`--headless`) and in the background (`&`):
`- google-chrome-stable --headless --disable-gpu --remote-debugging-port=9222 http://localhost &`
 
It's initially installed with the following config in `.travis.yml`:
```yml
 addons:
   chrome: stable
```
***See complete [`.travis.yml`](https://github.com/championer-org/championer_one/blob/88eaeb3a9dc86d643614841aa253cc0dcecae805/.travis.yml) file, at this point.***