### PR TITLE
63 lock files updates and npm jquery

### DIFF
--- a/assets/npm-shrinkwrap.json
+++ b/assets/npm-shrinkwrap.json
@@ -3248,6 +3248,11 @@
       "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
       "dev": true
     },
+    "jquery": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.3.1.tgz",
+      "integrity": "sha512-Ubldcmxp5np52/ENotGxlLe6aGMvmF4R8S6tZjsP6Knsaxd/xp3Zrh50cG93lR6nPXyUFwzN3ZSOQI0wRJNdGg=="
+    },
     "js-base64": {
       "version": "2.4.5",
       "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.4.5.tgz",

--- a/assets/package-lock.json
+++ b/assets/package-lock.json
@@ -3248,6 +3248,11 @@
       "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
       "dev": true
     },
+    "jquery": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.3.1.tgz",
+      "integrity": "sha512-Ubldcmxp5np52/ENotGxlLe6aGMvmF4R8S6tZjsP6Knsaxd/xp3Zrh50cG93lR6nPXyUFwzN3ZSOQI0wRJNdGg=="
+    },
     "js-base64": {
       "version": "2.4.5",
       "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.4.5.tgz",

--- a/assets/package.json
+++ b/assets/package.json
@@ -15,7 +15,7 @@
     "brunch": "^2.10.12",
     "clean-css-brunch": "2.10.0",
     "node-sass": "^4.9.0",
-    "sass-brunch": "^2.10.4",
+    "sass-brunch": "brunch/sass-brunch#2d47094d8c259f07030a99433bc935d1ab753914",
     "uglify-js-brunch": "2.10.0"
   },
   "engines": {


### PR DESCRIPTION
fixes #63 
 
Might disable `npm audit` for now, when it's ran after `npm ci`. Just a compromise, because this does eliminate the tendency for `npm i` to try to install `node-sass` 3.8.0, causing Heroku deploy to fail.
 
`sass-brunch` just needs to update its dependencies, because running `npm i` in the terminal, or as Heroku does, installs `node-sass` 4.5.3, which is better than how the outdated 2.10.4 release of `sass-brunch` tries to install `node-sass` 3.8.0, but still an outdated release.
 
Installs jQuery via npm, without introducing security vulnerabilities.
