### PR TITLE
Troubleshoot pr 62

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ before_script:
   - sudo chmod +x chromedriver
   - sudo mv chromedriver /usr/local/bin
   - nohup chromedriver &
-  - google-chrome-stable --headless --disable-gpu --remote-debugging-port=9222 http://localhost &
+  - google-chrome-stable --remote-debugging-port=9222 http://localhost &
 script:
   - mix test
   - mix credo

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ before_script:
   - sudo chmod +x chromedriver
   - sudo mv chromedriver /usr/local/bin
   - nohup chromedriver &
-  - google-chrome-stable --remote-debugging-port=9222 http://localhost &
+  - google-chrome-stable --headless --disable-gpu --remote-debugging-port=9222 http://localhost &
 script:
   - mix test
   - mix credo

--- a/lib/championer_one_web/templates/layout/footer.html.eex
+++ b/lib/championer_one_web/templates/layout/footer.html.eex
@@ -16,7 +16,7 @@
       <ul id="social-media">
         <li><%= link '', to: 'https://www.youtube.com/channel/UCqRP-fMnT3YUdnYqmkHDYOA', class: "fa fa-youtube-play fa-lg", id: "youtube-icon" %></li>
         <li><%= link '', to: 'https://twitter.com/ChampionerOrg', class: "fa fa-twitter fa-lg" %></li>
-        <li><%= link '', to: 'http://facebook.com/ChampionerOrg', class: "fa fa-facebook-official fa-lg" %></i></li>
+        <li><%= link '', to: 'http://facebook.com/ChampionerOrg', class: "fa fa-facebook-official fa-lg" %></li>
         <li><%= link '', to: "https://www.instagram.com/championerorg/", class: "fa fa-instagram fa-lg" %></li>
         <li><%= link '', to: 'http://medium.com/@ChampionerOrg', class: "fa fa-medium fa-lg" %></li>
       </ul>

--- a/lib/championer_one_web/templates/layout/footer.html.eex
+++ b/lib/championer_one_web/templates/layout/footer.html.eex
@@ -14,11 +14,11 @@
     <div class="col s2 center">
      <h5 class="yellow-text">Social Media</h5>
       <ul id="social-media">
-        <li><%= link '', to: 'https://www.youtube.com/channel/UCqRP-fMnT3YUdnYqmkHDYOA', class: "fa fa-youtube-play fa-lg", id: "youtube-icon" %></li>
-        <li><%= link '', to: 'https://twitter.com/ChampionerOrg', class: "fa fa-twitter fa-lg" %></li>
-        <li><%= link '', to: 'http://facebook.com/ChampionerOrg', class: "fa fa-facebook-official fa-lg" %></li>
-        <li><%= link '', to: "https://www.instagram.com/championerorg/", class: "fa fa-instagram fa-lg" %></li>
-        <li><%= link '', to: 'http://medium.com/@ChampionerOrg', class: "fa fa-medium fa-lg" %></li>
+        <li><%= link "YouTube", to: "https://www.youtube.com/channel/UCqRP-fMnT3YUdnYqmkHDYOA", class: "fa fa-youtube-play fa-lg", id: "youtube-icon" %></li>
+        <li><%= link "Twitter", to: "https://twitter.com/ChampionerOrg", class: "fa fa-twitter fa-lg" %></li>
+        <li><%= link "Facebook", to: "http://facebook.com/ChampionerOrg", class: "fa fa-facebook-official fa-lg" %></li>
+        <li><%= link "Instagram", to: "https://www.instagram.com/championerorg", class: "fa fa-instagram fa-lg" %></li>
+        <li><%= link "Medium", to: "http://medium.com/@ChampionerOrg", class: "fa fa-medium fa-lg" %></li>
       </ul>
     </div>
     <div class="col s5 center">

--- a/test/championer_one_web/acceptance/layout_footer_test.exs
+++ b/test/championer_one_web/acceptance/layout_footer_test.exs
@@ -93,7 +93,10 @@ defmodule ChampionerOneWeb.LayoutFooterTest do
     test "presence of Twitter link", %{parent_element: parent_element} do
       parent_element
       |> find_within_element(:class, "fa-twitter")
-      click({:class, "fa-twitter"})
+      |> move_to(10, 10)
+      mouse_down()
+      mouse_up()
+      # click({:class, "fa-twitter"})
       assert(current_url() == "https://twitter.com/ChampionerOrg")
     end
 

--- a/test/championer_one_web/acceptance/layout_footer_test.exs
+++ b/test/championer_one_web/acceptance/layout_footer_test.exs
@@ -103,6 +103,7 @@ defmodule ChampionerOneWeb.LayoutFooterTest do
     end
 
     test "presence of Instagram link", %{parent_element: parent_element} do
+      :timer.sleep(9000)
       parent_element
       |> find_within_element(:class, "fa-instagram")
       |> click()
@@ -115,9 +116,10 @@ defmodule ChampionerOneWeb.LayoutFooterTest do
     end
 
     test "presence of  Medium link", %{parent_element: parent_element} do
-      parent_element
-      |> find_within_element(:class, "fa-medium")
-      |> click()
+      link = parent_element
+             |> find_within_element(:class, "fa-medium")
+      :timer.sleep(9000)
+      click(link)
       assert(current_url() == "https://medium.com/@ChampionerOrg")
     end
   end

--- a/test/championer_one_web/acceptance/layout_footer_test.exs
+++ b/test/championer_one_web/acceptance/layout_footer_test.exs
@@ -84,8 +84,10 @@ defmodule ChampionerOneWeb.LayoutFooterTest do
     test "presence of YouTube link", %{parent_element: parent_element} do
       parent_element
       |> find_within_element(:id, "youtube-icon")
-      |> click()
-      assert(current_url() == "https://www.youtube.com/channel/UCqRP-fMnT3YUdnYqmkHDYOA")
+      |> element_displayed?()
+      |> assert()
+      # |> click()
+      # assert(current_url() == "https://www.youtube.com/channel/UCqRP-fMnT3YUdnYqmkHDYOA")
     end
 
     test "presence of Twitter link", %{parent_element: parent_element} do
@@ -96,8 +98,8 @@ defmodule ChampionerOneWeb.LayoutFooterTest do
     end
 
     test "presence of Facebook link", %{parent_element: parent_element} do
-      current_window_handle() |> maximize_window()
-      :timer.sleep(9000)
+      # current_window_handle() |> maximize_window()
+      # :timer.sleep(9000)
       parent_element
       |> find_within_element(:class, "fa-facebook-official")
       |> click()

--- a/test/championer_one_web/acceptance/layout_footer_test.exs
+++ b/test/championer_one_web/acceptance/layout_footer_test.exs
@@ -92,30 +92,20 @@ defmodule ChampionerOneWeb.LayoutFooterTest do
       parent_element
       |> find_within_element(:link_text, "Twitter")
       |> click()
-      # click({:class, "fa-twitter"})
       assert(current_url() == "https://twitter.com/ChampionerOrg")
     end
 
     test "presence of Facebook link", %{parent_element: parent_element} do
-      # current_window_handle() |> maximize_window()
-      # :timer.sleep(9000)
       parent_element
       |> find_within_element(:link_text, "Facebook")
       |> click()
-      # |> IO.inspect(label: "++++++++")
-      # |> click()
       assert(current_url() == "https://www.facebook.com/ChampionerOrg")
     end
 
     test "presence of Instagram link", %{parent_element: parent_element} do
-      #:timer.sleep(9000)
       parent_element
       |> find_within_element(:link_text, "Instagram")
       |> click()
-      # :timer.sleep(1000)
-      # IO.puts current_url()
-      # IO.inspect current_url(), label: "++++++++"
-      # assert(current_url() =~ "instagram.com/championerorg")
       assert(page_source() =~ "<title>ChampionerOrg (@championerorg)" <>
                               " • Instagram photos and videos</title>")
     end

--- a/test/championer_one_web/acceptance/layout_footer_test.exs
+++ b/test/championer_one_web/acceptance/layout_footer_test.exs
@@ -83,19 +83,15 @@ defmodule ChampionerOneWeb.LayoutFooterTest do
 
     test "presence of YouTube link", %{parent_element: parent_element} do
       parent_element
-      |> find_within_element(:id, "youtube-icon")
-      |> element_displayed?()
-      |> assert()
-      # |> click()
-      # assert(current_url() == "https://www.youtube.com/channel/UCqRP-fMnT3YUdnYqmkHDYOA")
+      |> find_within_element(:link_text, "YouTube")
+      |> click()
+      assert(current_url() == "https://www.youtube.com/channel/UCqRP-fMnT3YUdnYqmkHDYOA")
     end
 
     test "presence of Twitter link", %{parent_element: parent_element} do
       parent_element
-      |> find_within_element(:class, "fa-twitter")
-      |> move_to(10, 10)
-      mouse_down()
-      mouse_up()
+      |> find_within_element(:link_text, "Twitter")
+      |> click()
       # click({:class, "fa-twitter"})
       assert(current_url() == "https://twitter.com/ChampionerOrg")
     end
@@ -103,35 +99,31 @@ defmodule ChampionerOneWeb.LayoutFooterTest do
     test "presence of Facebook link", %{parent_element: parent_element} do
       # current_window_handle() |> maximize_window()
       # :timer.sleep(9000)
-      link_visibility = parent_element
-                       |> find_within_element(:class, "fa-facebook-official")
-                       |> css_property("visibility")
-      assert(link_visibility == "visible")
+      parent_element
+      |> find_within_element(:link_text, "Facebook")
+      |> click()
       # |> IO.inspect(label: "++++++++")
       # |> click()
-      # assert(current_url() == "https://www.facebook.com/ChampionerOrg")
+      assert(current_url() == "https://www.facebook.com/ChampionerOrg")
     end
 
     test "presence of Instagram link", %{parent_element: parent_element} do
       #:timer.sleep(9000)
       parent_element
-      |> find_within_element(:class, "fa-instagram")
-      # |> click()
-      element?(:class, "fa-instagram")
-      |> assert()
+      |> find_within_element(:link_text, "Instagram")
+      |> click()
       # :timer.sleep(1000)
       # IO.puts current_url()
       # IO.inspect current_url(), label: "++++++++"
       # assert(current_url() =~ "instagram.com/championerorg")
-      # assert(page_source() =~ "<title>ChampionerOrg (@championerorg)" <>
-                              # " • Instagram photos and videos</title>")
+      assert(page_source() =~ "<title>ChampionerOrg (@championerorg)" <>
+                              " • Instagram photos and videos</title>")
     end
 
     test "presence of  Medium link", %{parent_element: parent_element} do
-      link = parent_element
-             |> find_within_element(:class, "fa-medium")
-      #:timer.sleep(9000)
-      click(link)
+      parent_element
+      |> find_within_element(:link_text, "Medium")
+      |> click()
       assert(current_url() == "https://medium.com/@ChampionerOrg")
     end
   end

--- a/test/championer_one_web/acceptance/layout_footer_test.exs
+++ b/test/championer_one_web/acceptance/layout_footer_test.exs
@@ -93,17 +93,20 @@ defmodule ChampionerOneWeb.LayoutFooterTest do
     test "presence of Twitter link", %{parent_element: parent_element} do
       parent_element
       |> find_within_element(:class, "fa-twitter")
-      |> click()
+      click({:class, "fa-twitter"})
       assert(current_url() == "https://twitter.com/ChampionerOrg")
     end
 
     test "presence of Facebook link", %{parent_element: parent_element} do
       # current_window_handle() |> maximize_window()
       # :timer.sleep(9000)
-      parent_element
-      |> find_within_element(:class, "fa-facebook-official")
-      |> click()
-      assert(current_url() == "https://www.facebook.com/ChampionerOrg")
+      link_visibility = parent_element
+                       |> find_within_element(:class, "fa-facebook-official")
+                       |> css_property("visibility")
+      assert(link_visibility == "visible")
+      # |> IO.inspect(label: "++++++++")
+      # |> click()
+      # assert(current_url() == "https://www.facebook.com/ChampionerOrg")
     end
 
     test "presence of Instagram link", %{parent_element: parent_element} do

--- a/test/championer_one_web/acceptance/layout_footer_test.exs
+++ b/test/championer_one_web/acceptance/layout_footer_test.exs
@@ -113,13 +113,15 @@ defmodule ChampionerOneWeb.LayoutFooterTest do
       #:timer.sleep(9000)
       parent_element
       |> find_within_element(:class, "fa-instagram")
-      |> click()
+      # |> click()
+      element?(:class, "fa-instagram")
+      |> assert()
       # :timer.sleep(1000)
       # IO.puts current_url()
       # IO.inspect current_url(), label: "++++++++"
       # assert(current_url() =~ "instagram.com/championerorg")
-      assert(page_source() =~ "<title>ChampionerOrg (@championerorg)" <>
-                              " • Instagram photos and videos</title>")
+      # assert(page_source() =~ "<title>ChampionerOrg (@championerorg)" <>
+                              # " • Instagram photos and videos</title>")
     end
 
     test "presence of  Medium link", %{parent_element: parent_element} do

--- a/test/championer_one_web/acceptance/layout_footer_test.exs
+++ b/test/championer_one_web/acceptance/layout_footer_test.exs
@@ -96,6 +96,8 @@ defmodule ChampionerOneWeb.LayoutFooterTest do
     end
 
     test "presence of Facebook link", %{parent_element: parent_element} do
+      current_window_handle() |> maximize_window()
+      :timer.sleep(9000)
       parent_element
       |> find_within_element(:class, "fa-facebook-official")
       |> click()
@@ -103,7 +105,7 @@ defmodule ChampionerOneWeb.LayoutFooterTest do
     end
 
     test "presence of Instagram link", %{parent_element: parent_element} do
-      :timer.sleep(9000)
+      #:timer.sleep(9000)
       parent_element
       |> find_within_element(:class, "fa-instagram")
       |> click()
@@ -118,7 +120,7 @@ defmodule ChampionerOneWeb.LayoutFooterTest do
     test "presence of  Medium link", %{parent_element: parent_element} do
       link = parent_element
              |> find_within_element(:class, "fa-medium")
-      :timer.sleep(9000)
+      #:timer.sleep(9000)
       click(link)
       assert(current_url() == "https://medium.com/@ChampionerOrg")
     end


### PR DESCRIPTION
Going with `:link_text` instead of `:id` or `:css` finally worked on the font-awesome links that weren't passing the acceptance tests on Travis, but passing locally.
 
The elements were **present,** but **not displayed,** on the Travis build. So adding actual text links alongside the icons, and finding the elements via the text was a compromise to get to green and stop burning time on this.
 
![fa w/:link_text](https://dl.dropbox.com/s/bzt128i7owfs6uf/Screenshot%202018-06-21%2022.35.04.png)